### PR TITLE
Fix Performance section overflow on mobile iOS Edge

### DIFF
--- a/webapp/src/components/add-exercise/SetRow.tsx
+++ b/webapp/src/components/add-exercise/SetRow.tsx
@@ -22,7 +22,7 @@ export function SetRow({
 	disabled = false,
 }: SetRowProps) {
 	return (
-		<div className="grid grid-cols-[40px_1fr_1fr_40px] gap-2 items-center">
+		<div className="grid grid-cols-[32px_1fr_1fr_32px] sm:grid-cols-[40px_1fr_1fr_40px] gap-2 items-center">
 			<div className="text-center text-[var(--text-primary)] font-medium">
 				{setNumber}
 			</div>
@@ -49,7 +49,7 @@ export function SetRow({
 			<button
 				onClick={onDelete}
 				disabled={disabled}
-				className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-[var(--background-tertiary)] disabled:opacity-50 transition-colors"
+				className="w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center rounded-lg hover:bg-[var(--background-tertiary)] disabled:opacity-50 transition-colors"
 				aria-label="Delete set"
 			>
 				<TrashIcon size={18} className="text-[var(--accent-error)]" />

--- a/webapp/src/components/add-exercise/SetsManager.tsx
+++ b/webapp/src/components/add-exercise/SetsManager.tsx
@@ -67,7 +67,7 @@ export function SetsManager({
 			<h3 className="text-lg font-semibold text-[var(--text-primary)] mb-4">
 				Performance
 			</h3>
-			<div className="grid grid-cols-[40px_1fr_1fr_40px] gap-2 mb-2 px-1">
+			<div className="grid grid-cols-[32px_1fr_1fr_32px] sm:grid-cols-[40px_1fr_1fr_40px] gap-2 mb-2 px-1">
 				<div className="text-sm font-medium text-[var(--text-secondary)] text-center">
 					Set
 				</div>


### PR DESCRIPTION
## Summary
- Reduces fixed grid columns from 40px to 32px on mobile viewports
- Adds responsive breakpoint `sm:grid-cols-[40px_1fr_1fr_40px]` for larger screens
- Reduces delete button from 10x10 to 8x8 on mobile

Fixes #4

## Test plan
- [x] Test on iOS Edge browser with narrow viewport
- [x] Verify Performance section no longer overflows
- [x] Check desktop layout unchanged